### PR TITLE
Updating viztracer to save trace in /tmp.

### DIFF
--- a/src/appsvc_profiler/constants.py
+++ b/src/appsvc_profiler/constants.py
@@ -31,7 +31,7 @@ class CodeProfilerConstants():
     
     @property
     def CODE_PROFILER_TRACE_NAME(self):
-        return f"{self.CODE_PROFILER_LOGS_DIR}/{self.INSTANCE_ID_TRIMMED}_{self.CODE_PROFILER_TRACE_FILENAME}"    
+        return f"/tmp/{self.INSTANCE_ID_TRIMMED}_{self.CODE_PROFILER_TRACE_FILENAME}"    
     
     GUNICORN_LOGFILE_SIGNAL_HANDLER_INFO = "Worker.handle_usr1 of <gunicorn.workers.sync.SyncWorker object"
     INSTANCE_ID_ENV_NAME = "WEBSITE_INSTANCE_ID"

--- a/src/appsvc_profiler/installer.py
+++ b/src/appsvc_profiler/installer.py
@@ -42,6 +42,7 @@ class CodeProfilerInstaller:
                                    plugins=['vizplugins.cpu_usage','vizplugins.memory_usage'], 
                                    max_stack_depth=20)
                 self.logger.info("Attempting to install the default code profiler.")
+                self.logger.debug(f"viztracer would save traces to {constants.CODE_PROFILER_TRACE_NAME}")
                 tracer.install()
                 self.logger.info("Successfully installed code profiler.")
                 self._set_signal_handler_initialized_status(True)

--- a/src/appsvc_profiler/profiler.py
+++ b/src/appsvc_profiler/profiler.py
@@ -83,7 +83,7 @@ class CodeProfiler():
     def _get_output_file_path(self):
         output_filepath = self.output_filename
         if self.output_filename == "":
-               output_filepath = self._get_new_file_name()
+            output_filepath = self._get_new_file_name()
             
         if not self._looks_like_absolute_path(output_filepath):                    
             output_filepath = f"{constants.CODE_PROFILER_LOGS_DIR}/{output_filepath}"
@@ -108,7 +108,7 @@ class CodeProfiler():
             # renaming the file only if the name is different from constants.CODE_PROFILER_TRACE_FILENAME
             if self.output_filename != constants.CODE_PROFILER_TRACE_FILENAME:
                 if path.exists(constants.CODE_PROFILER_TRACE_NAME):
-                    # move /home/LogFiles/CodeProfiler/instance_id_profiler_trace.json to /exithome/LogFiles/CodeProfiler/<timestamp>_instanceid_profiler_trace.json
+                    # move /tmp/instance_id_profiler_trace.json to /home/LogFiles/CodeProfiler/<timestamp>_instanceid_profiler_trace.json
                     shutil.move(constants.CODE_PROFILER_TRACE_NAME , f"{output_file_path}")
                 else:
                     log_info(f"- Unable to save the trace by the name {output_file_path}")


### PR DESCRIPTION
Previously viztracer was saving the trace to /home/LogFiles/CodeProfiler directory. This was on file share and hence the operation was slow. 

Updating this behaviour such that the trace is saved to /tmp.